### PR TITLE
update database to support polysemy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ distantlife.db
 distantlifebk.db
 distantlife.ini
 dump.rdb
+
+# Local-only reference files
+.local/

--- a/README.md
+++ b/README.md
@@ -33,6 +33,39 @@ In addition to the member experience, there is an admin dashboard available to u
 - Add new words to word sets using a CSV file uploader
 - Delete words from word sets
 
+#### CSV Upload Format
+
+The uploader expects at least 5 columns in this exact order:
+
+1. First language name (must match an entry in `languages.name`)
+2. First language pronunciation
+3. Second language name (must match an entry in `languages.name`)
+4. Second language pronunciation
+5. `word_type` (must match an entry in `word_type.type`, for example `noun`)
+
+The first row must be headers. Header text is used to detect each column.
+
+Required pattern:
+
+```csv
+<Language1>,<Language1Pronunciation>,<Language2>,<Language2Pronunciation>,word_type
+```
+
+How column direction works in the admin UI:
+
+- The selected set gets the second language column.
+- If you choose "Add first column to additional set", the first language column is added to that additional set.
+
+Example: Upload to a Hebrew set (Translated language) with native language English:
+
+```csv
+English,en_pronunciation,עברית,he_pronunciation,word_type
+dog,dawg,כלב,kelev,noun
+cat,kat,חתול,chatul,noun
+```
+
+Optional extra columns are currently ignored by the importer, so you can include reference-only columns (for example a nikkud variant) without breaking upload.
+
 ### 🪐 Localization and Internationalization
 
 To better support users, the site supports language translation and internationalization. For languages that require a right-to-left (RTL) reading direction, the interface mirrors the normal reading direction. In addition, RTL includes small enhancements such as flipping the active pet image and general site layout.

--- a/application.py
+++ b/application.py
@@ -206,6 +206,34 @@ def edit_set():
         return render_template("editsets.html", sets=sets, role=role)
 
 
+@app.route("/edit/word/", methods=["GET", "POST"])
+@login_required
+@admin_required
+def edit_word():
+    """Admin: Placeholder word edit route that redirects to the containing set editor."""
+    word_id = request.values.get("word_id")
+    if not word_id:
+        flash("Missing word id")
+        return redirect("/edit/set")
+
+    set_row = None
+    if using_lemma_schema():
+        set_row = db.execute(
+            "SELECT word_set_id FROM set_item WHERE sense_id = ? ORDER BY id ASC LIMIT 1",
+            (int(word_id),),
+        ).fetchone()
+    else:
+        set_row = db.execute(
+            "SELECT word_set_id FROM word_set_words WHERE word_id = ? ORDER BY id ASC LIMIT 1",
+            (int(word_id),),
+        ).fetchone()
+
+    flash("Word inline editing is not implemented yet; opened the set editor instead.")
+    if set_row is not None:
+        return redirect(f"/edit/set/?set_id={int(set_row['word_set_id'])}")
+    return redirect("/edit/set")
+
+
 @app.route("/quiz/set/", methods=["GET", "POST"])
 @login_required
 def quizset():

--- a/application.py
+++ b/application.py
@@ -14,8 +14,9 @@ from werkzeug.utils import secure_filename
 
 from flask_babel import Babel
 from connections import REDIS_URL, get_db_connection, get_redis_client
-from helpers import apology, login_required, admin_required, usd, set_active_pet_in_session, set_languages, get_sets, get_set_by_id, get_words_by_set_id, get_role, get_word_translation, update_experience, session_get_int
+from helpers import apology, login_required, admin_required, usd, set_active_pet_in_session, set_languages, get_sets, get_set_by_id, get_words_by_set_id, get_role, get_word_translation, update_experience, session_get_int, using_lemma_schema
 from fileparser import save_words
+from normalization import compute_search_key
 
 r = get_redis_client()
 
@@ -278,33 +279,102 @@ def createset():
         if request.form.get('setname') is not None:
 
             setname = request.form.get('setname')
-            learning_lang = request.form.get('learning_lang')
+            learning_lang = int(request.form.get('learning_lang'))
             plang_setname = request.form.get('plang_setname')
-            preferred_lang = request.form.get('preferred_lang')
+            preferred_lang = int(request.form.get('preferred_lang'))
 
-            # Sets will usually be a noun
-            learning_wordid = (db.execute("INSERT INTO words (language_id, type, pronunciation, wordstr) VALUES (?, ?, ?, ?)",
-                                         (learning_lang, 1, '', setname, ))).lastrowid
-            con.commit()
+            if using_lemma_schema():
+                language_rows = db.execute(
+                    "SELECT id, charcode FROM languages WHERE id IN (?, ?)",
+                    (learning_lang, preferred_lang),
+                ).fetchall()
+                lang_code_map = {int(row['id']): (row['charcode'] or '') for row in language_rows}
 
-            preferred_wordid = (db.execute("INSERT INTO words (language_id, type, pronunciation, wordstr) VALUES (?, ?, ?, ?)",
-                                          (preferred_lang, 1, '', plang_setname, ))).lastrowid
-            con.commit()
+                learning_lemma_id = db.execute(
+                    "INSERT INTO lemma (language_id, pos_id, pronunciation, audiopath) VALUES (?, ?, ?, ?)",
+                    (learning_lang, 1, '', None),
+                ).lastrowid
+                db.execute(
+                    "INSERT INTO lemma_form (lemma_id, language_id, form_type, script, value, search_key, is_primary) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        learning_lemma_id,
+                        learning_lang,
+                        'surface',
+                        'Hebr' if lang_code_map.get(learning_lang, '').lower() == 'he' else 'Latn',
+                        setname,
+                        compute_search_key(setname, lang_code_map.get(learning_lang, '')),
+                        1,
+                    ),
+                )
+                learning_sense_id = db.execute(
+                    "INSERT INTO sense (lemma_id, part_of_speech, is_primary) VALUES (?, ?, ?)",
+                    (learning_lemma_id, 1, 1),
+                ).lastrowid
 
-            db.execute("INSERT INTO word_translation (orig_lang, trans_lang, orig_word, trans_word) VALUES (?, ?, ?, ?)",
-                       (preferred_lang, learning_lang, preferred_wordid, learning_wordid, )).fetchall()
-            db.execute("INSERT INTO word_translation (orig_lang, trans_lang, orig_word, trans_word) VALUES (?, ?, ?, ?)",
-                       (learning_lang, preferred_lang, learning_wordid, preferred_wordid, )).fetchall()
-            con.commit()
+                preferred_lemma_id = db.execute(
+                    "INSERT INTO lemma (language_id, pos_id, pronunciation, audiopath) VALUES (?, ?, ?, ?)",
+                    (preferred_lang, 1, '', None),
+                ).lastrowid
+                db.execute(
+                    "INSERT INTO lemma_form (lemma_id, language_id, form_type, script, value, search_key, is_primary) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                    (
+                        preferred_lemma_id,
+                        preferred_lang,
+                        'surface',
+                        'Hebr' if lang_code_map.get(preferred_lang, '').lower() == 'he' else 'Latn',
+                        plang_setname,
+                        compute_search_key(plang_setname, lang_code_map.get(preferred_lang, '')),
+                        1,
+                    ),
+                )
+                preferred_sense_id = db.execute(
+                    "INSERT INTO sense (lemma_id, part_of_speech, is_primary) VALUES (?, ?, ?)",
+                    (preferred_lemma_id, 1, 1),
+                ).lastrowid
 
-            # TODO Set a default image here
-            insert_word_set = (db.execute("INSERT INTO word_sets (imgsrc, set_name_word_id, language_id) VALUES (?, ?, ?)",
-                                         ("/sets/fruits.png", learning_wordid, learning_lang, ))).lastrowid
-            con.commit()
+                db.execute(
+                    "INSERT INTO sense_translation (source_sense_id, target_sense_id, relation_type) VALUES (?, ?, ?)",
+                    (preferred_sense_id, learning_sense_id, 'exact'),
+                )
+                db.execute(
+                    "INSERT INTO sense_translation (source_sense_id, target_sense_id, relation_type) VALUES (?, ?, ?)",
+                    (learning_sense_id, preferred_sense_id, 'exact'),
+                )
 
-            insert_word_set_orig = (db.execute("INSERT INTO word_sets (imgsrc, set_name_word_id, language_id) VALUES (?, ?, ?)",
-                                              ("/sets/fruits.png", preferred_wordid, preferred_lang, ))).lastrowid
-            con.commit()
+                insert_word_set = db.execute(
+                    "INSERT INTO word_sets (imgsrc, set_name_word_id, language_id, set_name_sense_id) VALUES (?, ?, ?, ?)",
+                    ("/sets/fruits.png", None, learning_lang, learning_sense_id),
+                ).lastrowid
+                insert_word_set_orig = db.execute(
+                    "INSERT INTO word_sets (imgsrc, set_name_word_id, language_id, set_name_sense_id) VALUES (?, ?, ?, ?)",
+                    ("/sets/fruits.png", None, preferred_lang, preferred_sense_id),
+                ).lastrowid
+                con.commit()
+
+            else:
+                # Sets will usually be a noun
+                learning_wordid = (db.execute("INSERT INTO words (language_id, type, pronunciation, wordstr) VALUES (?, ?, ?, ?)",
+                                            (learning_lang, 1, '', setname, ))).lastrowid
+                con.commit()
+
+                preferred_wordid = (db.execute("INSERT INTO words (language_id, type, pronunciation, wordstr) VALUES (?, ?, ?, ?)",
+                                            (preferred_lang, 1, '', plang_setname, ))).lastrowid
+                con.commit()
+
+                db.execute("INSERT INTO word_translation (orig_lang, trans_lang, orig_word, trans_word) VALUES (?, ?, ?, ?)",
+                        (preferred_lang, learning_lang, preferred_wordid, learning_wordid, )).fetchall()
+                db.execute("INSERT INTO word_translation (orig_lang, trans_lang, orig_word, trans_word) VALUES (?, ?, ?, ?)",
+                        (learning_lang, preferred_lang, learning_wordid, preferred_wordid, )).fetchall()
+                con.commit()
+
+                # TODO Set a default image here
+                insert_word_set = (db.execute("INSERT INTO word_sets (imgsrc, set_name_word_id, language_id) VALUES (?, ?, ?)",
+                                            ("/sets/fruits.png", learning_wordid, learning_lang, ))).lastrowid
+                con.commit()
+
+                insert_word_set_orig = (db.execute("INSERT INTO word_sets (imgsrc, set_name_word_id, language_id) VALUES (?, ?, ?)",
+                                                ("/sets/fruits.png", preferred_wordid, preferred_lang, ))).lastrowid
+                con.commit()
 
             if (insert_word_set > 0):
                 flash("New set created: " + setname)
@@ -331,9 +401,15 @@ def delete_word():
     if request.method == "POST":
         if request.form.get('word_id') is not None:
             if request.form.get('word_set_id') is not None:
-                # delete word from word_sets
-                deleteqry = db.execute("DELETE FROM word_set_words WHERE word_id = ? and word_set_id = ?",
-                                       (request.form.get("word_id"), request.form.get("word_set_id")))
+                if using_lemma_schema():
+                    deleteqry = db.execute(
+                        "DELETE FROM set_item WHERE sense_id = ? and word_set_id = ?",
+                        (request.form.get("word_id"), request.form.get("word_set_id")),
+                    )
+                else:
+                    # delete word from word_sets
+                    deleteqry = db.execute("DELETE FROM word_set_words WHERE word_id = ? and word_set_id = ?",
+                                        (request.form.get("word_id"), request.form.get("word_set_id")))
                 con.commit()
                 if (deleteqry.rowcount > 0):
                     flash('delete successful')

--- a/enhance_lemma_forms.py
+++ b/enhance_lemma_forms.py
@@ -1,0 +1,102 @@
+import argparse
+import sqlite3
+
+from normalization import compute_search_key, has_nikkud, strip_nikkud
+
+
+def get_hebrew_language_ids(db):
+    rows = db.execute(
+        "SELECT id FROM languages WHERE lower(charcode) = 'he' OR lower(name) = 'hebrew' OR name = 'עברית'"
+    ).fetchall()
+    return {int(row["id"]) for row in rows}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Enhance lemma forms by adding plain Hebrew variants for niqqud forms."
+    )
+    parser.add_argument(
+        "--db",
+        default="distantlife.db",
+        help="Path to the SQLite database file (default: distantlife.db)",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    con = sqlite3.connect(args.db)
+    con.row_factory = sqlite3.Row
+    db = con
+
+    hebrew_language_ids = get_hebrew_language_ids(db)
+    if not hebrew_language_ids:
+        print("No Hebrew language id found; skipping form enhancement.")
+        return
+
+    placeholders = ",".join(["?"] * len(hebrew_language_ids))
+    primary_forms = db.execute(
+        f"""
+        SELECT lf.id, lf.lemma_id, lf.value, lf.language_id
+                         , lf.search_key
+        FROM lemma_form lf
+        WHERE lf.is_primary = 1
+          AND lf.language_id IN ({placeholders})
+        """,
+        tuple(hebrew_language_ids),
+    ).fetchall()
+
+    inserted_plain_forms = 0
+    updated_search_keys = 0
+
+    for form in primary_forms:
+        value = form["value"] or ""
+        language_id = int(form["language_id"])
+        search_key = compute_search_key(value, "he")
+
+        if (form["search_key"] or "") != search_key:
+            db.execute(
+                "UPDATE lemma_form SET search_key = ? WHERE id = ?",
+                (search_key, int(form["id"])),
+            )
+            updated_search_keys += 1
+
+        if not has_nikkud(value):
+            continue
+
+        plain_value = strip_nikkud(value)
+        existing = db.execute(
+            """
+            SELECT 1
+            FROM lemma_form
+            WHERE lemma_id = ? AND language_id = ? AND value = ?
+            LIMIT 1
+            """,
+            (int(form["lemma_id"]), language_id, plain_value),
+        ).fetchone()
+
+        if existing:
+            continue
+
+        db.execute(
+            """
+            INSERT INTO lemma_form (lemma_id, language_id, form_type, script, value, search_key, is_primary)
+            VALUES (?, ?, 'surface', 'Hebr', ?, ?, 0)
+            """,
+            (
+                int(form["lemma_id"]),
+                language_id,
+                plain_value,
+                compute_search_key(plain_value, "he"),
+            ),
+        )
+        inserted_plain_forms += 1
+
+    con.commit()
+    print(f"Updated search_key on primary forms: {updated_search_keys}")
+    print(f"Inserted plain Hebrew forms: {inserted_plain_forms}")
+
+
+if __name__ == "__main__":
+    main()

--- a/fileparser.py
+++ b/fileparser.py
@@ -1,10 +1,23 @@
 import csv
 from connections import get_db_connection, get_redis_client
+from normalization import compute_search_key
 
 con = get_db_connection()
 db = con
 
 r = get_redis_client()
+
+
+def table_exists(table_name):
+    row = db.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table_name,),
+    ).fetchone()
+    return row is not None
+
+
+def using_lemma_schema():
+    return table_exists("lemma") and table_exists("set_item")
 
 
 def save_words(csvf, word_set_id, orig_set_id=''):
@@ -51,38 +64,110 @@ def save_words(csvf, word_set_id, orig_set_id=''):
     lang2p = headings[3]  # Translation transliteration
     wtype = headings[4]  # Type of word (noun, verb)
 
-    orig_lang_id = (db.execute(
-        "SELECT id FROM languages WHERE name = ?", (lang1, )).fetchall())[0]['id']
-    trans_lang_id = (db.execute(
-        "SELECT id FROM languages WHERE name = ?", (lang2, )).fetchall())[0]['id']
+    orig_lang_row = db.execute(
+        "SELECT id, charcode FROM languages WHERE name = ?",
+        (lang1,),
+    ).fetchone()
+    trans_lang_row = db.execute(
+        "SELECT id, charcode FROM languages WHERE name = ?",
+        (lang2,),
+    ).fetchone()
+
+    orig_lang_id = int(orig_lang_row['id'])
+    trans_lang_id = int(trans_lang_row['id'])
+    orig_lang_code = (orig_lang_row['charcode'] or '').lower()
+    trans_lang_code = (trans_lang_row['charcode'] or '').lower()
 
     for w in words:
         word_type_id = (db.execute(
             "SELECT id FROM word_type WHERE type = ?", (w[wtype], )).fetchall())[0]['id']
 
-        new_orig_word_id = (db.execute("INSERT INTO words ('wordstr', 'language_id', 'type', 'pronunciation') VALUES (?, ?, ?, ?)",
-                                      (w[lang1], orig_lang_id, word_type_id, w[lang1p])
-                                      )).lastrowid
-        con.commit()
-        new_translated_word_id = (db.execute("INSERT INTO words ('wordstr', 'language_id', 'type', 'pronunciation') VALUES (?, ?, ?, ?)",
-                                            (w[lang2], trans_lang_id, word_type_id,  w[lang2p])
-                                            )).lastrowid
-        con.commit()
-        db.execute("INSERT INTO word_set_words (word_set_id, word_id) VALUES (?, ?)",
-                   (word_set_id, new_translated_word_id))
-        con.commit()
-        # if orig_set_id is set
-        if (orig_set_id != ''):
-            db.execute("INSERT INTO word_set_words (word_set_id, word_id) VALUES (?, ?)",
-                       (int(orig_set_id), new_orig_word_id))
+        if using_lemma_schema():
+            new_orig_lemma_id = db.execute(
+                "INSERT INTO lemma (language_id, pos_id, pronunciation, audiopath) VALUES (?, ?, ?, ?)",
+                (orig_lang_id, word_type_id, w[lang1p], None),
+            ).lastrowid
+            db.execute(
+                "INSERT INTO lemma_form (lemma_id, language_id, form_type, script, value, search_key, is_primary) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    new_orig_lemma_id,
+                    orig_lang_id,
+                    'surface',
+                    'Hebr' if orig_lang_code == 'he' else 'Latn',
+                    w[lang1],
+                    compute_search_key(w[lang1], orig_lang_code),
+                    1,
+                ),
+            )
+            new_orig_sense_id = db.execute(
+                "INSERT INTO sense (lemma_id, part_of_speech, is_primary) VALUES (?, ?, ?)",
+                (new_orig_lemma_id, word_type_id, 1),
+            ).lastrowid
+
+            new_trans_lemma_id = db.execute(
+                "INSERT INTO lemma (language_id, pos_id, pronunciation, audiopath) VALUES (?, ?, ?, ?)",
+                (trans_lang_id, word_type_id, w[lang2p], None),
+            ).lastrowid
+            db.execute(
+                "INSERT INTO lemma_form (lemma_id, language_id, form_type, script, value, search_key, is_primary) VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    new_trans_lemma_id,
+                    trans_lang_id,
+                    'surface',
+                    'Hebr' if trans_lang_code == 'he' else 'Latn',
+                    w[lang2],
+                    compute_search_key(w[lang2], trans_lang_code),
+                    1,
+                ),
+            )
+            new_trans_sense_id = db.execute(
+                "INSERT INTO sense (lemma_id, part_of_speech, is_primary) VALUES (?, ?, ?)",
+                (new_trans_lemma_id, word_type_id, 1),
+            ).lastrowid
+
+            db.execute(
+                "INSERT INTO set_item (word_set_id, sense_id, prompt_mode) VALUES (?, ?, ?)",
+                (int(word_set_id), new_trans_sense_id, 'show_all_forms'),
+            )
+            if (orig_set_id != ''):
+                db.execute(
+                    "INSERT INTO set_item (word_set_id, sense_id, prompt_mode) VALUES (?, ?, ?)",
+                    (int(orig_set_id), new_orig_sense_id, 'show_all_forms'),
+                )
+
+            db.execute(
+                "INSERT INTO sense_translation (source_sense_id, target_sense_id, relation_type) VALUES (?, ?, ?)",
+                (new_orig_sense_id, new_trans_sense_id, 'exact'),
+            )
+            db.execute(
+                "INSERT INTO sense_translation (source_sense_id, target_sense_id, relation_type) VALUES (?, ?, ?)",
+                (new_trans_sense_id, new_orig_sense_id, 'exact'),
+            )
             con.commit()
-        # insert orig and its translation equivalent
-        db.execute("INSERT INTO word_translation (orig_lang, trans_lang, orig_word, trans_word) VALUES (?, ?, ?, ?)",
-                   (orig_lang_id, trans_lang_id, new_orig_word_id, new_translated_word_id))
-        con.commit()
-        # reverse orig & translation
-        db.execute("INSERT INTO word_translation (orig_lang, trans_lang, orig_word, trans_word) VALUES (?, ?, ?, ?)",
-                   (trans_lang_id, orig_lang_id, new_translated_word_id, new_orig_word_id))
-        con.commit()
+        else:
+            new_orig_word_id = (db.execute("INSERT INTO words ('wordstr', 'language_id', 'type', 'pronunciation') VALUES (?, ?, ?, ?)",
+                                        (w[lang1], orig_lang_id, word_type_id, w[lang1p])
+                                        )).lastrowid
+            con.commit()
+            new_translated_word_id = (db.execute("INSERT INTO words ('wordstr', 'language_id', 'type', 'pronunciation') VALUES (?, ?, ?, ?)",
+                                                (w[lang2], trans_lang_id, word_type_id,  w[lang2p])
+                                                )).lastrowid
+            con.commit()
+            db.execute("INSERT INTO word_set_words (word_set_id, word_id) VALUES (?, ?)",
+                    (word_set_id, new_translated_word_id))
+            con.commit()
+            # if orig_set_id is set
+            if (orig_set_id != ''):
+                db.execute("INSERT INTO word_set_words (word_set_id, word_id) VALUES (?, ?)",
+                        (int(orig_set_id), new_orig_word_id))
+                con.commit()
+            # insert orig and its translation equivalent
+            db.execute("INSERT INTO word_translation (orig_lang, trans_lang, orig_word, trans_word) VALUES (?, ?, ?, ?)",
+                    (orig_lang_id, trans_lang_id, new_orig_word_id, new_translated_word_id))
+            con.commit()
+            # reverse orig & translation
+            db.execute("INSERT INTO word_translation (orig_lang, trans_lang, orig_word, trans_word) VALUES (?, ?, ?, ?)",
+                    (trans_lang_id, orig_lang_id, new_translated_word_id, new_orig_word_id))
+            con.commit()
     file.close()
     return len(words)

--- a/helpers.py
+++ b/helpers.py
@@ -1,11 +1,24 @@
 from flask import redirect, render_template, session
 from functools import wraps
 from connections import get_db_connection, get_redis_client
+from lexicon import get_primary_form_for_sense, get_sense_translations
 
 con = get_db_connection()
 db = con
 
 r = get_redis_client()
+
+
+def table_exists(table_name):
+    row = db.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table_name,),
+    ).fetchone()
+    return row is not None
+
+
+def using_lemma_schema():
+    return table_exists("lemma") and table_exists("set_item")
 
 
 def apology(message, code=400):
@@ -109,9 +122,36 @@ def get_word_translation(word_id, orig_lang='', trans_lang=''):
     if (trans_lang == ''):
         trans_lang = session.get('language')['learning']
 
+    if using_lemma_schema():
+        source_sense_id = int(word_id)
+        translated_senses = get_sense_translations(db, source_sense_id, orig_lang)
+
+        # Fallback for legacy IDs during transition.
+        if len(translated_senses) == 0:
+            mapped = db.execute(
+                """
+                SELECT s.id AS sense_id
+                FROM lemma l
+                JOIN sense s ON s.lemma_id = l.id AND s.is_primary = 1
+                WHERE l.legacy_word_id = ?
+                LIMIT 1
+                """,
+                (int(word_id),),
+            ).fetchone()
+            if mapped is not None:
+                source_sense_id = int(mapped['sense_id'])
+                translated_senses = get_sense_translations(db, source_sense_id, orig_lang)
+
+        if len(translated_senses) == 0:
+            return ''
+
+        form = get_primary_form_for_sense(db, int(translated_senses[0]['sense_id']))
+        return form['value'] if form is not None else ''
+
     translation = db.execute("SELECT wordstr FROM words where id = (SELECT word_translation.trans_word FROM words JOIN word_translation ON word_translation.orig_word = words.id WHERE words.id = ? AND word_translation.trans_lang = ? AND word_translation.orig_lang = ?)",
                              (word_id, orig_lang, trans_lang, )).fetchall()
-
+    if len(translation) == 0:
+        return ''
     return translation[0]['wordstr']
 
 
@@ -128,15 +168,40 @@ def get_sets(language_id='', trans_lang=''):
         trans_lang = session.get('language')['learning']
     if (language_id == ''):
         language_id = session.get('language')['preferred']
-    setsqry = db.execute("SELECT word_sets.id as id, words.wordstr as wordstr, words.id as setnameid, word_sets.imgsrc FROM word_sets JOIN words ON word_sets.set_name_word_id = words.id WHERE word_sets.language_id =  ?", 
-                    (trans_lang, )).fetchall()
+
+    if using_lemma_schema():
+        setsqry = db.execute(
+            """
+            SELECT word_sets.id AS id,
+                   word_sets.imgsrc AS imgsrc,
+                   word_sets.set_name_sense_id AS setnameid,
+                   lf.value AS wordstr
+            FROM word_sets
+            LEFT JOIN sense s ON s.id = word_sets.set_name_sense_id
+            LEFT JOIN lemma_form lf ON lf.lemma_id = s.lemma_id AND lf.is_primary = 1
+            WHERE word_sets.language_id = ?
+            """,
+            (trans_lang,),
+        ).fetchall()
+    else:
+        setsqry = db.execute("SELECT word_sets.id as id, words.wordstr as wordstr, words.id as setnameid, word_sets.imgsrc FROM word_sets JOIN words ON word_sets.set_name_word_id = words.id WHERE word_sets.language_id =  ?", 
+                        (trans_lang, )).fetchall()
+
     sets = []
     for setinfo in setsqry:
         translation = get_word_translation(
             int(setinfo['setnameid']), language_id, trans_lang)
-        totalcount = db.execute(
-            "select count(*) as count from word_set_words where word_set_id =  ?", 
-            (setinfo['id'], )).fetchall()
+
+        if using_lemma_schema():
+            totalcount = db.execute(
+                "select count(*) as count from set_item where word_set_id =  ?",
+                (setinfo['id'],),
+            ).fetchall()
+        else:
+            totalcount = db.execute(
+                "select count(*) as count from word_set_words where word_set_id =  ?", 
+                (setinfo['id'], )).fetchall()
+
         setinfo = {
             "id": setinfo['id'],
             "set_name": setinfo['wordstr'],
@@ -159,8 +224,24 @@ def get_set_by_id(set_id):
           - setnameid - word ID of wordstr
           - imgsrc - image path for set cover image
     """
-    setsqry = db.execute("SELECT word_sets.id as id, words.wordstr as wordstr, words.id as setnameid, word_sets.imgsrc FROM word_sets JOIN words ON word_sets.set_name_word_id = words.id WHERE word_sets.language_id =  ? AND word_sets.id = ?", 
-                  (session.get('language')['learning'], set_id, )).fetchall()
+    if using_lemma_schema():
+        setsqry = db.execute(
+            """
+            SELECT word_sets.id AS id,
+                   lf.value AS wordstr,
+                   word_sets.set_name_sense_id AS setnameid,
+                   word_sets.imgsrc AS imgsrc
+            FROM word_sets
+            LEFT JOIN sense s ON s.id = word_sets.set_name_sense_id
+            LEFT JOIN lemma_form lf ON lf.lemma_id = s.lemma_id AND lf.is_primary = 1
+            WHERE word_sets.language_id = ? AND word_sets.id = ?
+            """,
+            (session.get('language')['learning'], set_id),
+        ).fetchall()
+    else:
+        setsqry = db.execute("SELECT word_sets.id as id, words.wordstr as wordstr, words.id as setnameid, word_sets.imgsrc FROM word_sets JOIN words ON word_sets.set_name_word_id = words.id WHERE word_sets.language_id =  ? AND word_sets.id = ?", 
+                    (session.get('language')['learning'], set_id, )).fetchall()
+
     return setsqry[0]
 
 
@@ -172,8 +253,27 @@ def get_words_by_set_id(set_id):
       :returns: 
           - list of words
     """
-    words = db.execute("SELECT words.id, words.wordstr, words.pronunciation, word_type.type FROM words JOIN word_set_words ON word_set_words.word_id = words.id JOIN word_type ON words.type = word_type.id where word_set_words.word_set_id = ?", 
-                  (set_id, )).fetchall()
+    if using_lemma_schema():
+        words = db.execute(
+            """
+            SELECT s.id AS id,
+                   lf.value AS wordstr,
+                   COALESCE(l.pronunciation, '') AS pronunciation,
+                   COALESCE(word_type.type, '') AS type,
+                   l.audiopath AS audiosrc
+            FROM set_item
+            JOIN sense s ON s.id = set_item.sense_id
+            JOIN lemma l ON l.id = s.lemma_id
+            LEFT JOIN lemma_form lf ON lf.lemma_id = l.id AND lf.is_primary = 1
+            LEFT JOIN word_type ON word_type.id = s.part_of_speech
+            WHERE set_item.word_set_id = ?
+            ORDER BY set_item.id ASC
+            """,
+            (set_id,),
+        ).fetchall()
+    else:
+        words = db.execute("SELECT words.id, words.wordstr, words.pronunciation, word_type.type, words.audiopath AS audiosrc FROM words JOIN word_set_words ON word_set_words.word_id = words.id JOIN word_type ON words.type = word_type.id where word_set_words.word_set_id = ?", 
+                    (set_id, )).fetchall()
     return words
 
 

--- a/lexicon.py
+++ b/lexicon.py
@@ -1,0 +1,138 @@
+from normalization import compute_search_key
+
+
+def _query_all(db, sql, params=()):
+    return db.execute(sql, params).fetchall()
+
+
+def _query_one(db, sql, params=()):
+    return db.execute(sql, params).fetchone()
+
+
+def get_primary_form_for_sense(db, sense_id):
+    """Return the primary form for a sense, or fallback to any form."""
+    row = _query_one(
+        db,
+        """
+        SELECT lf.value, lf.search_key, lf.script, lf.form_type, lf.language_id
+        FROM sense s
+        JOIN lemma_form lf ON lf.lemma_id = s.lemma_id
+        WHERE s.id = ?
+        ORDER BY lf.is_primary DESC, lf.id ASC
+        LIMIT 1
+        """,
+        (sense_id,),
+    )
+    return row
+
+
+def get_sense_forms(db, sense_id):
+    """Return all forms for the lemma connected to a sense."""
+    return _query_all(
+        db,
+        """
+        SELECT lf.id, lf.value, lf.search_key, lf.script, lf.form_type, lf.is_primary, lf.language_id
+        FROM sense s
+        JOIN lemma_form lf ON lf.lemma_id = s.lemma_id
+        WHERE s.id = ?
+        ORDER BY lf.is_primary DESC, lf.id ASC
+        """,
+        (sense_id,),
+    )
+
+
+def get_sense_translations(db, source_sense_id, target_language_id=None):
+    """Return translated senses for a source sense, optionally filtered by language."""
+    params = [source_sense_id]
+    language_filter = ""
+    if target_language_id is not None:
+        language_filter = " AND l.language_id = ?"
+        params.append(target_language_id)
+
+    return _query_all(
+        db,
+        f"""
+        SELECT
+            st.target_sense_id AS sense_id,
+            s.lemma_id,
+            s.gloss,
+            s.part_of_speech,
+            l.language_id,
+            st.relation_type
+        FROM sense_translation st
+        JOIN sense s ON s.id = st.target_sense_id
+        JOIN lemma l ON l.id = s.lemma_id
+        WHERE st.source_sense_id = ?{language_filter}
+        ORDER BY st.id ASC
+        """,
+        tuple(params),
+    )
+
+
+def get_set_senses(db, word_set_id):
+    """Return the senses assigned to a set with primary display form."""
+    return _query_all(
+        db,
+        """
+        SELECT
+            si.sense_id,
+            s.lemma_id,
+            s.gloss,
+            s.part_of_speech,
+            l.language_id,
+            l.pronunciation,
+            lf.value AS wordstr,
+            lf.search_key,
+            lf.script
+        FROM set_item si
+        JOIN sense s ON s.id = si.sense_id
+        JOIN lemma l ON l.id = s.lemma_id
+        JOIN lemma_form lf ON lf.lemma_id = l.id
+        WHERE si.word_set_id = ?
+          AND lf.is_primary = 1
+        ORDER BY si.id ASC
+        """,
+        (word_set_id,),
+    )
+
+
+def search_senses(db, text, language_id=None, limit=20):
+    """Search senses by normalized form key."""
+    if limit < 1:
+        limit = 1
+
+    lang_code = ""
+    if language_id is not None:
+        lang = _query_one(db, "SELECT charcode FROM languages WHERE id = ?", (language_id,))
+        if lang:
+            lang_code = lang["charcode"]
+
+    key = compute_search_key(text, lang_code)
+    params = [f"%{key}%"]
+
+    language_filter = ""
+    if language_id is not None:
+        language_filter = " AND l.language_id = ?"
+        params.append(language_id)
+
+    params.append(limit)
+
+    return _query_all(
+        db,
+        f"""
+        SELECT
+            s.id AS sense_id,
+            s.lemma_id,
+            s.gloss,
+            l.language_id,
+            lf.value AS primary_form,
+            lf.search_key
+        FROM sense s
+        JOIN lemma l ON l.id = s.lemma_id
+        JOIN lemma_form lf ON lf.lemma_id = l.id AND lf.is_primary = 1
+        WHERE lf.search_key LIKE ?{language_filter}
+        ORDER BY lf.search_key ASC
+        LIMIT ?
+        """,
+        tuple(params),
+    )

--- a/migration_report.py
+++ b/migration_report.py
@@ -1,0 +1,114 @@
+import argparse
+import sqlite3
+import sys
+
+REPORT_QUERIES = {
+    "row_counts": """
+        SELECT (SELECT COUNT(*) FROM words_old) AS old_words,
+               (SELECT COUNT(*) FROM lemma) AS lemma_count,
+               (SELECT COUNT(*) FROM sense WHERE is_primary = 1) AS primary_sense_count
+    """,
+    "translation_counts": """
+        SELECT (SELECT COUNT(*) FROM word_translation_old) AS old_translation_rows,
+               (SELECT COUNT(*) FROM sense_translation) AS sense_translation_rows
+    """,
+    "set_counts": """
+        SELECT (SELECT COUNT(*) FROM word_set_words_old) AS old_set_rows,
+               (SELECT COUNT(*) FROM set_item) AS set_item_rows
+    """,
+    "orphan_lemma_forms": """
+        SELECT COUNT(*) AS orphan_lemma_forms
+        FROM lemma_form lf
+        LEFT JOIN lemma l ON l.id = lf.lemma_id
+        WHERE l.id IS NULL
+    """,
+    "orphan_senses": """
+        SELECT COUNT(*) AS orphan_senses
+        FROM sense s
+        LEFT JOIN lemma l ON l.id = s.lemma_id
+        WHERE l.id IS NULL
+    """,
+    "orphan_set_items": """
+        SELECT COUNT(*) AS orphan_set_items
+        FROM set_item si
+        LEFT JOIN sense s ON s.id = si.sense_id
+        WHERE s.id IS NULL
+    """,
+    "words_learned_without_sense": """
+        SELECT COUNT(*) AS words_learned_without_sense
+        FROM words_learned
+        WHERE word IS NOT NULL AND sense_id IS NULL
+    """,
+    "duplicate_primary_search_keys": """
+        SELECT lf.language_id, lf.search_key, COUNT(*) AS duplicate_count
+        FROM lemma_form lf
+        WHERE lf.is_primary = 1
+        GROUP BY lf.language_id, lf.search_key
+        HAVING COUNT(*) > 1
+        ORDER BY duplicate_count DESC, lf.search_key ASC
+        LIMIT 20
+    """,
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Run post-cutover validation checks for lemma/sense schema."
+    )
+    parser.add_argument(
+        "--db",
+        default="distantlife.db",
+        help="Path to SQLite database (default: distantlife.db)",
+    )
+    return parser.parse_args()
+
+
+def run_query(db, name, sql):
+    rows = db.execute(sql).fetchall()
+    print(f"\n[{name}]")
+    if not rows:
+        print("(no rows)")
+        return rows
+
+    columns = rows[0].keys()
+    print(" | ".join(columns))
+    for row in rows:
+        print(" | ".join(str(row[col]) for col in columns))
+    return rows
+
+
+def main():
+    args = parse_args()
+
+    con = sqlite3.connect(args.db)
+    con.row_factory = sqlite3.Row
+    db = con
+
+    has_errors = False
+
+    for name, sql in REPORT_QUERIES.items():
+        try:
+            rows = run_query(db, name, sql)
+        except sqlite3.OperationalError as exc:
+            print(f"\n[{name}] ERROR: {exc}")
+            has_errors = True
+            continue
+
+        if name in {
+            "orphan_lemma_forms",
+            "orphan_senses",
+            "orphan_set_items",
+            "words_learned_without_sense",
+        } and rows and int(rows[0][0]) > 0:
+            has_errors = True
+
+    con.close()
+    if has_errors:
+        print("\nValidation completed with warnings/errors.")
+        sys.exit(1)
+
+    print("\nValidation completed successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/migrations/001_big_bang_lemma_cutover.sql
+++ b/migrations/001_big_bang_lemma_cutover.sql
@@ -1,0 +1,138 @@
+PRAGMA foreign_keys = OFF;
+BEGIN TRANSACTION;
+
+-- Preserve old tables for rollback window.
+ALTER TABLE words RENAME TO words_old;
+ALTER TABLE word_translation RENAME TO word_translation_old;
+ALTER TABLE word_set_words RENAME TO word_set_words_old;
+
+-- Core lexical model.
+CREATE TABLE lemma (
+    id INTEGER PRIMARY KEY,
+    language_id INTEGER NOT NULL,
+    pos_id INTEGER,
+    pronunciation TEXT,
+    audiopath TEXT,
+    legacy_word_id INTEGER UNIQUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE lemma_form (
+    id INTEGER PRIMARY KEY,
+    lemma_id INTEGER NOT NULL,
+    language_id INTEGER NOT NULL,
+    form_type TEXT NOT NULL DEFAULT 'surface',
+    script TEXT,
+    value TEXT NOT NULL,
+    search_key TEXT NOT NULL,
+    is_primary INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(lemma_id, value)
+);
+
+CREATE TABLE sense (
+    id INTEGER PRIMARY KEY,
+    lemma_id INTEGER NOT NULL,
+    gloss TEXT,
+    part_of_speech INTEGER,
+    is_primary INTEGER NOT NULL DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE sense_translation (
+    id INTEGER PRIMARY KEY,
+    source_sense_id INTEGER NOT NULL,
+    target_sense_id INTEGER NOT NULL,
+    relation_type TEXT NOT NULL DEFAULT 'exact',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(source_sense_id, target_sense_id)
+);
+
+CREATE TABLE set_item (
+    id INTEGER PRIMARY KEY,
+    word_set_id INTEGER NOT NULL,
+    sense_id INTEGER NOT NULL,
+    prompt_mode TEXT NOT NULL DEFAULT 'show_all_forms',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(word_set_id, sense_id)
+);
+
+-- Helpful indexes for query and search performance.
+CREATE INDEX idx_lemma_language ON lemma(language_id);
+CREATE INDEX idx_lemma_legacy_word ON lemma(legacy_word_id);
+CREATE INDEX idx_lemma_form_lemma ON lemma_form(lemma_id);
+CREATE INDEX idx_lemma_form_search ON lemma_form(search_key, language_id);
+CREATE INDEX idx_sense_lemma ON sense(lemma_id);
+CREATE INDEX idx_sense_translation_source ON sense_translation(source_sense_id);
+CREATE INDEX idx_sense_translation_target ON sense_translation(target_sense_id);
+CREATE INDEX idx_set_item_set ON set_item(word_set_id);
+
+-- Backfill lemma and forms from old words.
+INSERT INTO lemma (language_id, pos_id, pronunciation, audiopath, legacy_word_id)
+SELECT w.language_id, w.type, w.pronunciation, w.audiopath, w.id
+FROM words_old w;
+
+INSERT INTO lemma_form (lemma_id, language_id, form_type, script, value, search_key, is_primary)
+SELECT l.id,
+       l.language_id,
+       'surface',
+       CASE
+         WHEN lower(lang.charcode) = 'he' THEN 'Hebr'
+         ELSE 'Latn'
+       END,
+       COALESCE(w.wordstr, ''),
+       lower(trim(COALESCE(w.wordstr, ''))),
+       1
+FROM lemma l
+JOIN words_old w ON w.id = l.legacy_word_id
+LEFT JOIN languages lang ON lang.id = l.language_id;
+
+-- One primary sense per existing word as migration baseline.
+INSERT INTO sense (lemma_id, gloss, part_of_speech, is_primary)
+SELECT l.id, NULL, l.pos_id, 1
+FROM lemma l;
+
+-- Backfill sense-to-sense translations using legacy word mappings.
+INSERT OR IGNORE INTO sense_translation (source_sense_id, target_sense_id, relation_type)
+SELECT s_from.id,
+       s_to.id,
+       'exact'
+FROM word_translation_old wt
+JOIN lemma l_from ON l_from.legacy_word_id = wt.orig_word
+JOIN lemma l_to ON l_to.legacy_word_id = wt.trans_word
+JOIN sense s_from ON s_from.lemma_id = l_from.id AND s_from.is_primary = 1
+JOIN sense s_to ON s_to.lemma_id = l_to.id AND s_to.is_primary = 1;
+
+-- Backfill set membership to sense level.
+INSERT OR IGNORE INTO set_item (word_set_id, sense_id, prompt_mode)
+SELECT wsw.word_set_id,
+       s.id,
+       'show_all_forms'
+FROM word_set_words_old wsw
+JOIN lemma l ON l.legacy_word_id = wsw.word_id
+JOIN sense s ON s.lemma_id = l.id AND s.is_primary = 1;
+
+-- Preserve set naming while adding sense-aware linkage.
+ALTER TABLE word_sets ADD COLUMN set_name_sense_id INTEGER;
+UPDATE word_sets
+SET set_name_sense_id = (
+    SELECT s.id
+    FROM lemma l
+    JOIN sense s ON s.lemma_id = l.id AND s.is_primary = 1
+    WHERE l.legacy_word_id = word_sets.set_name_word_id
+    LIMIT 1
+);
+
+-- Keep legacy progress data and add sense-aware progress column.
+ALTER TABLE words_learned ADD COLUMN sense_id INTEGER;
+UPDATE words_learned
+SET sense_id = (
+    SELECT s.id
+    FROM lemma l
+    JOIN sense s ON s.lemma_id = l.id AND s.is_primary = 1
+    WHERE l.legacy_word_id = words_learned.word
+    LIMIT 1
+);
+
+COMMIT;
+PRAGMA foreign_keys = ON;

--- a/migrations/001_validate_lemma_cutover.sql
+++ b/migrations/001_validate_lemma_cutover.sql
@@ -1,0 +1,38 @@
+-- Basic row-count checks.
+SELECT (SELECT COUNT(*) FROM words_old) AS old_words,
+       (SELECT COUNT(*) FROM lemma) AS lemma_count,
+       (SELECT COUNT(*) FROM sense WHERE is_primary = 1) AS primary_sense_count;
+
+SELECT (SELECT COUNT(*) FROM word_translation_old) AS old_translation_rows,
+       (SELECT COUNT(*) FROM sense_translation) AS sense_translation_rows;
+
+SELECT (SELECT COUNT(*) FROM word_set_words_old) AS old_set_rows,
+       (SELECT COUNT(*) FROM set_item) AS set_item_rows;
+
+-- Integrity checks.
+SELECT COUNT(*) AS orphan_lemma_forms
+FROM lemma_form lf
+LEFT JOIN lemma l ON l.id = lf.lemma_id
+WHERE l.id IS NULL;
+
+SELECT COUNT(*) AS orphan_senses
+FROM sense s
+LEFT JOIN lemma l ON l.id = s.lemma_id
+WHERE l.id IS NULL;
+
+SELECT COUNT(*) AS orphan_set_items
+FROM set_item si
+LEFT JOIN sense s ON s.id = si.sense_id
+WHERE s.id IS NULL;
+
+SELECT COUNT(*) AS words_learned_without_sense
+FROM words_learned
+WHERE word IS NOT NULL AND sense_id IS NULL;
+
+-- Potential duplicates in canonical search keys.
+SELECT lf.language_id, lf.search_key, COUNT(*) AS duplicate_count
+FROM lemma_form lf
+WHERE lf.is_primary = 1
+GROUP BY lf.language_id, lf.search_key
+HAVING COUNT(*) > 1
+ORDER BY duplicate_count DESC, lf.search_key ASC;

--- a/normalization.py
+++ b/normalization.py
@@ -1,0 +1,35 @@
+import re
+import unicodedata
+
+# Hebrew cantillation and niqqud marks.
+HEBREW_NIKKUD_RE = re.compile(r"[\u0591-\u05C7]")
+WHITESPACE_RE = re.compile(r"\s+")
+
+
+def strip_nikkud(text):
+    """Return Hebrew text without niqqud/cantillation marks."""
+    if text is None:
+        return ""
+    normalized = unicodedata.normalize("NFC", str(text))
+    return HEBREW_NIKKUD_RE.sub("", normalized)
+
+
+def has_nikkud(text):
+    """Return True if the text contains Hebrew niqqud/cantillation marks."""
+    if not text:
+        return False
+    return HEBREW_NIKKUD_RE.search(str(text)) is not None
+
+
+def compute_search_key(text, language_code=""):
+    """Build a normalized search key for indexed lookups."""
+    if text is None:
+        return ""
+
+    value = unicodedata.normalize("NFC", str(text)).strip()
+    code = (language_code or "").strip().lower()
+    if code in {"he", "heb", "hebrew"}:
+        value = strip_nikkud(value)
+
+    value = WHITESPACE_RE.sub(" ", value)
+    return value.lower()

--- a/scripts/preflight_prod.sh
+++ b/scripts/preflight_prod.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_FILE="${DB_FILE:-distantlife.db}"
+APP_ENTRY="${APP_ENTRY:-application.py}"
+REDIS_URL_EFFECTIVE="${REDIS_URL:-redis://127.0.0.1:6379/0}"
+
+pass() {
+  printf "[PASS] %s\n" "$1"
+}
+
+fail() {
+  printf "[FAIL] %s\n" "$1"
+  exit 1
+}
+
+warn() {
+  printf "[WARN] %s\n" "$1"
+}
+
+printf "Running Distant Life production preflight...\n"
+
+command -v python >/dev/null 2>&1 || fail "python is not available on PATH"
+pass "python is available"
+
+[[ -f "$APP_ENTRY" ]] || fail "missing app entry file: $APP_ENTRY"
+pass "app entry file present: $APP_ENTRY"
+
+[[ -n "${SECRET_KEY:-}" ]] || fail "SECRET_KEY is not set"
+[[ "${#SECRET_KEY}" -ge 16 ]] || fail "SECRET_KEY is set but too short (< 16 chars)"
+pass "SECRET_KEY is set"
+
+[[ -f "$DB_FILE" ]] || fail "database file not found: $DB_FILE"
+[[ -r "$DB_FILE" ]] || fail "database file is not readable: $DB_FILE"
+[[ -w "$DB_FILE" ]] || fail "database file is not writable: $DB_FILE"
+pass "database file is present/readable/writable: $DB_FILE"
+
+python - <<'PY' || fail "python dependency or runtime checks failed"
+import os
+import sqlite3
+import sys
+
+required_imports = [
+    "flask",
+    "flask_session",
+    "flask_babel",
+    "flask_limiter",
+    "redis",
+]
+
+for mod in required_imports:
+    __import__(mod)
+
+db_file = os.environ.get("DB_FILE", "distantlife.db")
+conn = sqlite3.connect(db_file)
+conn.row_factory = sqlite3.Row
+
+required_tables = ["users", "languages", "word_sets"]
+for table in required_tables:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?",
+        (table,),
+    ).fetchone()
+    if row is None:
+        raise RuntimeError(f"missing table: {table}")
+
+lemma_table = conn.execute(
+    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='lemma'"
+).fetchone()
+set_item_table = conn.execute(
+    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='set_item'"
+).fetchone()
+if lemma_table is None or set_item_table is None:
+    raise RuntimeError("database is not migrated to lemma schema (missing lemma/set_item)")
+
+conn.close()
+PY
+pass "python imports and sqlite schema checks passed"
+
+python - <<'PY' || fail "redis connection check failed"
+import os
+import redis
+
+redis_url = os.environ.get("REDIS_URL", "redis://127.0.0.1:6379/0")
+client = redis.from_url(redis_url)
+client.ping()
+PY
+pass "redis is reachable at ${REDIS_URL_EFFECTIVE}"
+
+if [[ "${FLASK_ENV:-}" == "development" ]]; then
+  warn "FLASK_ENV=development in production environment"
+fi
+
+printf "Preflight complete: ready to start the app.\n"

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -14,6 +14,15 @@
 </div>
 <h2>{{ _('News') }}</h2>
 <div class="card">
+     <h3>March 29, 2026</h3>
+     <ul>
+       <li>Updated database structure to support polysemy (multiple meanings per word)</li>
+       <li>Added password peek for register and update password sections</li>
+       <li>Hardened authentication requirements</li>
+     </ul>
+  </div>
+
+<div class="card">
      <h3>December 15, 2021</h3>
      <p>Added features:</p>
      <ul>


### PR DESCRIPTION
# Lemma/Sense Cutover + Admin/Import Updates

## Summary
This PR implements the planned lexical-model cutover from word-level mappings to a lemma/sense structure, while keeping the application operational through migration and transition.

The work includes:
- Big-bang migration SQL with backfill from legacy tables.
- Post-migration validation SQL.
- Dual-schema runtime support in key helper, route, and CSV import paths.
- Search/normalization helpers to support broader form matching.
- Admin UX safeguard for the missing edit-word endpoint.
- Documentation updates for CSV upload format and behavior.

## Why
The previous schema represented translations and set membership at the word row level, which limited support for variants and sense-level modeling.

This PR introduces a lemma/sense foundation to enable:
- Multiple forms per lexical item.
- Sense-based set membership.
- More flexible matching and future expansion (plain/marked forms, richer translation relationships).

## Scope of Changes

### 1) Database Migration and Validation
- Added migration script:
  - migrations/001_big_bang_lemma_cutover.sql
- Added validation script:
  - migrations/001_validate_lemma_cutover.sql

Migration behavior:
- Renames legacy tables for rollback window:
  - words -> words_old
  - word_translation -> word_translation_old
  - word_set_words -> word_set_words_old
- Creates new core tables:
  - lemma
  - lemma_form
  - sense
  - sense_translation
  - set_item
- Backfills data from legacy structures to new model.
- Adds sense-aware references for existing set names/progress mappings where applicable.

### 2) Runtime Dual-Schema Support
Updated application logic to support both legacy and lemma schemas during transition:
- helpers.py
  - schema detection helpers
  - dual-path queries in translation/set retrieval functions
- application.py
  - dual-path create/delete set-item behavior
  - added /edit/word/ route fallback to avoid 404 and redirect admins to set editor
- fileparser.py
  - dual-path CSV import writes for old/new schema states

### 3) Lexicon/Normalization Utilities
Added utilities to support normalization and migration enhancement workflow:
- lexicon.py
- normalization.py
- enhance_lemma_forms.py
- migration_report.py

### 4) Docs and Operational Quality
- README.md
  - added clear CSV upload format section
  - documented column order and direction behavior in admin UI
- .gitignore
  - added .local/ for local-only artifacts

## CSV Import Behavior (Documented)
- Uploader requires at least 5 columns in expected order:
  1. First language name
  2. First language pronunciation
  3. Second language name
  4. Second language pronunciation
  5. word_type
- The selected set receives the second-language column.
- Optional additional set receives first-language column.
- Extra columns are ignored.

## Manual Validation Performed
Local migration + manual smoke checks completed:
- Migration script executed on local DB copy and local DB.
- Validation SQL executed successfully post-migration.
- App smoke tests passed:
  - login flow
  - training flow
  - admin delete word from set
  - CSV import + set creation path
  - quiz completion and experience gain updates
- Verified admin routing no longer fails on /edit/word/ requests (fallback redirect in place).

## Risk and Mitigation
- Risk: schema cutover regression in production.
- Mitigation:
  - preflight validation script added:
    - scripts/preflight_prod.sh
  - local migration/validation run before production
  - preserved legacy tables during rollback window
  - dual-schema code paths reduce transition fragility

## Deployment Notes
Recommended deployment approach for this PR:
- Deploy code.
- Deploy tested migrated DB file (distantlife.db) for clean cutover when legacy prod data retention is not required.
- Run preflight checks:
  - scripts/preflight_prod.sh
- Restart app and run smoke tests.

## Rollback Plan
If immediate issues occur post-deploy:
- Restore previous code + previous DB backup.
- Keep rollback window short and monitored.
- Do not re-run cutover migration on an already-migrated DB without reset/restore.

## Follow-up Work (Not in this PR)
- Implement true inline word edit UI/flow for /edit/word/ (current behavior is safe redirect fallback).
- After stability window, archive/drop legacy *_old tables in a dedicated cleanup migration.

## Reviewer Checklist
- Confirm migration and validation SQL are understandable and deterministic.
- Confirm dual-schema runtime branches are correct for both states.
- Confirm CSV docs match parser behavior.
- Confirm admin fallback route behavior is acceptable for this release.
- Confirm deployment/rollback steps are acceptable for production runbook.
